### PR TITLE
Fixes #7 - Use insertMany instead of create to save documents in order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -25,7 +25,7 @@ var fixtures = module.exports = function(dataset, db, callback) {
         var model = db.model(tableName);
 
         if (model) {
-            model.create(dataset[tableName], function(err) {
+            model.insertMany(dataset[tableName], function(err) {
                 done(err, Array.prototype.slice.call(arguments, 1));
             });
         } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-mongoose-fixtures",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "description": "Easy way to create mongoose fixtures.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The [insertMany](http://mongoosejs.com/docs/api.html#insertmany_insertMany) method has a default option set in true called "ordered". This fixes the issue described at #7 